### PR TITLE
Split out content blocks by section/type

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -75,187 +75,50 @@ $ const buttonStyle = {
 
       <common-table-spacer-element height="6" />
 
-      <if(withImage && imagePosition === 'right' && content.primaryImage)>
-        <tr>
-          <td align="center" valign="top" dir="ltr">
-            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td align="left" valign="top">
-                  <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
-                    <tr>
-                      <td align="left" valign="top">
-                        <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl>
-                          ${content.name}
-                        </a>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
-                          <common-table-spacer-element height="5" />
-                          <tr>
-                            <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
-                              ${content.teaser}
-                            </td>
-                          </tr>
-                          <if(readMore)>
-                            <common-table-spacer-element height="9" />
-                            <common-cta-element link-url=contentUrl />
-                          </if>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-                <td align="right" valign="top" width="200" class="wdt">
-                  <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
-                    <marko-newsletter-imgix
-                      src=image.src
-                      alt=image.alt
-                      options={ w: 400, h: 266, fit: "crop", auto: "format,compress" }
-                      class="img_resize2"
-                      attrs={ border: 0, width: 200, height: 133, style: imgStyles }
-                    >
-                      <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles } />
-                    </marko-newsletter-imgix>
-                  </marko-core-obj-value>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-        <tr>
-          <td align="left" valign="top" class="hide_on_mobile" style="display: none;mso-hide: all;">
-            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
-              <common-table-spacer-element height="10" />
-              <tr>
-                <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
-                  ${content.teaser}
-                </td>
-              </tr>
-              <if(readMore)>
-                <common-table-spacer-element height="9" />
-                <common-cta-element link-url=contentUrl />
-              </if>
-            </table>
-          </td>
-        </tr>
+      <if(sectionName === 'On the Move')>
+        <on-the-move-list-item-block content=content img-styles=imgStyles />
       </if>
 
-      <else-if(sectionName === 'In the Margins')>
-        <tr>
-          <td align="center" valign="top" dir="ltr">
-            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td align="left" valign="top">
-                  <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
-                    <tr>
-                      <td align="left" valign="top">
-                        <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl>
-                          ${content.name}
-                        </a>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
-                          <common-table-spacer-element height="5" />
-                          <tr>
-                            <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
-                              ${content.teaser}
-                            </td>
-                          </tr>
-                          <if(voteNow)>
-                            <common-table-spacer-element height="9" />
-                            <common-cta-element link-url=contentUrl />
-                          </if>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-                <td align="right" valign="top" width="200" class="wdt">
-                  <marko-newsletter-imgix
-                    src='/files/base/diverse/all/image/static/newsletter/InTheMarginsArtv6.png'
-                    alt='In the Margins'
-                    options={ w: 400, h: 266, fit: "crop", auto: "format,compress" }
-                    class="img_resize2"
-                    attrs={ border: 0, width: 200, height: 133, style: imgStyles }
-                  >
-                    <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles } />
-                  </marko-newsletter-imgix>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-        <tr>
-          <td align="left" valign="top" class="hide_on_mobile" style="display: none;mso-hide: all;">
-            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
-              <common-table-spacer-element height="10" />
-              <tr>
-                <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
-                  ${content.teaser}
-                </td>
-              </tr>
-              <if(readMore)>
-                <common-table-spacer-element height="9" />
-                <common-cta-element link-url=contentUrl />
-              </if>
-            </table>
-          </td>
-        </tr>
+      <else-if(sectionName === 'Podcast' || sectionName === 'Podcasts')>
+        <podcast-list-item-block
+          content=content
+          img-styles=imgStyles
+          img-link-styles=imgLinkStyles
+          read-more=readMore
+          content-url=contentUrl
+          vote-now=voteNow
+        />
       </else-if>
 
       <else-if(sectionName === "Poll")>
-        <tr>
-          <td align="center" valign="top">
-            <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
-              ${content.name}
-            </a>
-          </td>
-        </tr>
-        <if(withTeaser)>
-          <common-table-spacer-element height="5" />
-          <tr>
-            <td align="center" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
-              ${content.teaser}
-            </td>
-          </tr>
-        </if>
-        <if(voteNow)>
-          <common-table-spacer-element height="9" />
-          <tr>
-            <td align="center" valign="middle">
-              <a href=contentUrl target="_blank">
-                <span style=buttonStyle>&nbsp;Vote Now&nbsp;</span>
-              </a>
-            </td>
-          </tr>
-        </if>
+        <poll-list-item-block
+          content=content
+          with-teaser=withTeaser
+          vote-now=voteNow
+          content-url=contentUrl
+          button-style=buttonStyle
+        />
+      </else-if>
+
+      <else-if(withImage && imagePosition === 'right' && content.primaryImage)>
+        <common-content-with-image-list-item-block
+          content=content
+          read-more=readMore
+          content-url=contentUrl
+          img-styles=imgStyles
+          img-link-styles=imgLinkStyles
+        />
       </else-if>
 
       <else>
-        <tr>
-          <td align="left" valign="top">
-            <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
-              ${content.name}
-            </a>
-          </td>
-        </tr>
-        <if(withTeaser)>
-          <common-table-spacer-element height="5" />
-          <tr>
-            <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
-              ${content.teaser}
-            </td>
-          </tr>
-        </if>
-        <if(readMore)>
-          <common-table-spacer-element height="9" />
-          <common-cta-element link-url=contentUrl />
-        </if>
+        <common-content-no-image-list-item-block
+          content=content
+          content-url=contentUrl
+          with-teaser=withTeaser
+          read-more=readMore
+        />
       </else>
+
       <common-table-spacer-element height="32" />
     </table>
   </td>

--- a/packages/common/components/blocks/content/marko.json
+++ b/packages/common/components/blocks/content/marko.json
@@ -1,4 +1,7 @@
 {
+  "taglib-imports": [
+    "./section-specific/marko.json"
+  ],
   "<common-content-background-block>": {
     "template": "./background.marko"
   },
@@ -10,5 +13,11 @@
   },
   "<common-content-magazine-cover-block>": {
     "template": "./magazine-cover.marko"
+  },
+  "<common-content-with-image-list-item-block>": {
+    "template": "./with-image.marko"
+  },
+  "<common-content-no-image-list-item-block>": {
+    "template": "./no-image.marko"
   }
 }

--- a/packages/common/components/blocks/content/no-image.marko
+++ b/packages/common/components/blocks/content/no-image.marko
@@ -1,0 +1,21 @@
+$ const { content, contentUrl, withTeaser, readMore } = input;
+
+<tr>
+  <td align="left" valign="top">
+    <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
+      ${content.name}
+    </a>
+  </td>
+</tr>
+<if(withTeaser)>
+  <common-table-spacer-element height="5" />
+  <tr>
+    <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+      ${content.teaser}
+    </td>
+  </tr>
+</if>
+<if(readMore)>
+  <common-table-spacer-element height="9" />
+  <common-cta-element link-url=contentUrl />
+</if>

--- a/packages/common/components/blocks/content/section-specific/marko.json
+++ b/packages/common/components/blocks/content/section-specific/marko.json
@@ -1,0 +1,11 @@
+{
+  "<on-the-move-list-item-block>": {
+    "template": "./on-the-move.marko"
+  },
+  "<podcast-list-item-block>": {
+    "template": "./podcast.marko"
+  },
+  "<poll-list-item-block>": {
+    "template": "./poll.marko"
+  }
+}

--- a/packages/common/components/blocks/content/section-specific/on-the-move.marko
+++ b/packages/common/components/blocks/content/section-specific/on-the-move.marko
@@ -1,0 +1,55 @@
+$ const { content, imgStyles } = input;
+
+<tr>
+  <td align="center" valign="top" dir="ltr">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td align="left" valign="top">
+          <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
+            <tr>
+              <td align="left" valign="top" style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;">
+                  ${content.name}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
+                  <common-table-spacer-element height="5" />
+                  <tr>
+                    <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+                      ${content.teaser}
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+        <td align="right" valign="top" width="200" class="wdt">
+          <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
+            <marko-newsletter-imgix
+              src=image.src
+              alt=image.alt
+              options={ w: 400, h: 266, fit: "crop", auto: "format,compress" }
+              class="img_resize2"
+              attrs={ border: 0, width: 200, height: 133, style: imgStyles }
+            >
+            </marko-newsletter-imgix>
+          </marko-core-obj-value>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td align="left" valign="top" class="hide_on_mobile" style="display: none;mso-hide: all;">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
+      <common-table-spacer-element height="10" />
+      <tr>
+        <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+          ${content.teaser}
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/packages/common/components/blocks/content/section-specific/podcast.marko
+++ b/packages/common/components/blocks/content/section-specific/podcast.marko
@@ -35,7 +35,7 @@ $ const { content, imgStyles, imgLinkStyles, readMore, contentUrl, voteNow } = i
           <marko-newsletter-imgix
             src='/files/base/diverse/all/image/static/newsletter/InTheMarginsArtv6.png'
             alt='In the Margins'
-            options={ w: 400, h: 266, fit: "crop", auto: "format,compress" }
+            options={ w: 400, h: 266, auto: "format,compress" }
             class="img_resize2"
             attrs={ border: 0, width: 200, height: 133, style: imgStyles }
           >

--- a/packages/common/components/blocks/content/section-specific/podcast.marko
+++ b/packages/common/components/blocks/content/section-specific/podcast.marko
@@ -1,0 +1,64 @@
+$ const { content, imgStyles, imgLinkStyles, readMore, contentUrl, voteNow } = input;
+
+<tr>
+  <td align="center" valign="top" dir="ltr">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td align="left" valign="top">
+          <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
+            <tr>
+              <td align="left" valign="top">
+                <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl>
+                  ${content.name}
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
+                  <common-table-spacer-element height="5" />
+                  <tr>
+                    <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+                      ${content.teaser}
+                    </td>
+                  </tr>
+                  <if(voteNow)>
+                    <common-table-spacer-element height="9" />
+                    <common-cta-element link-url=contentUrl />
+                  </if>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+        <td align="right" valign="top" width="200" class="wdt">
+          <marko-newsletter-imgix
+            src='/files/base/diverse/all/image/static/newsletter/InTheMarginsArtv6.png'
+            alt='In the Margins'
+            options={ w: 400, h: 266, fit: "crop", auto: "format,compress" }
+            class="img_resize2"
+            attrs={ border: 0, width: 200, height: 133, style: imgStyles }
+          >
+            <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles } />
+          </marko-newsletter-imgix>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td align="left" valign="top" class="hide_on_mobile" style="display: none;mso-hide: all;">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
+      <common-table-spacer-element height="10" />
+      <tr>
+        <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+          ${content.teaser}
+        </td>
+      </tr>
+      <if(readMore)>
+        <common-table-spacer-element height="9" />
+        <common-cta-element link-url=contentUrl />
+      </if>
+    </table>
+  </td>
+</tr>

--- a/packages/common/components/blocks/content/section-specific/poll.marko
+++ b/packages/common/components/blocks/content/section-specific/poll.marko
@@ -1,0 +1,27 @@
+$ const { content, withTeaser, voteNow, contentUrl, buttonStyle } = input;
+
+<tr>
+  <td align="center" valign="top">
+    <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
+      ${content.name}
+    </a>
+  </td>
+</tr>
+<if(withTeaser)>
+  <common-table-spacer-element height="5" />
+  <tr>
+    <td align="center" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+      ${content.teaser}
+    </td>
+  </tr>
+</if>
+<if(voteNow)>
+  <common-table-spacer-element height="9" />
+  <tr>
+    <td align="center" valign="middle">
+      <a href=contentUrl target="_blank">
+        <span style=buttonStyle>&nbsp;Vote Now&nbsp;</span>
+      </a>
+    </td>
+  </tr>
+</if>

--- a/packages/common/components/blocks/content/with-image.marko
+++ b/packages/common/components/blocks/content/with-image.marko
@@ -1,0 +1,66 @@
+$ const { content, readMore, contentUrl, imgStyles, imgLinkStyles } = input;
+
+<tr>
+  <td align="center" valign="top" dir="ltr">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td align="left" valign="top">
+          <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
+            <tr>
+              <td align="left" valign="top">
+                <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl>
+                  ${content.name}
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
+                  <common-table-spacer-element height="5" />
+                  <tr>
+                    <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+                      ${content.teaser}
+                    </td>
+                  </tr>
+                  <if(readMore)>
+                    <common-table-spacer-element height="9" />
+                    <common-cta-element link-url=contentUrl />
+                  </if>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+        <td align="right" valign="top" width="200" class="wdt">
+          <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
+            <marko-newsletter-imgix
+              src=image.src
+              alt=image.alt
+              options={ w: 400, h: 266, fit: "crop", auto: "format,compress" }
+              class="img_resize2"
+              attrs={ border: 0, width: 200, height: 133, style: imgStyles }
+            >
+              <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles } />
+            </marko-newsletter-imgix>
+          </marko-core-obj-value>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td align="left" valign="top" class="hide_on_mobile" style="display: none;mso-hide: all;">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
+      <common-table-spacer-element height="10" />
+      <tr>
+        <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+          ${content.teaser}
+        </td>
+      </tr>
+      <if(readMore)>
+        <common-table-spacer-element height="9" />
+        <common-cta-element link-url=contentUrl />
+      </if>
+    </table>
+  </td>
+</tr>


### PR DESCRIPTION
This additionally added a content block for the On the Move section that removes links to the site (per request). Otherwise all this is doing is splitting out the section specific and type specific (image vs no-image) content blocks into their own components making them easier to work with so we only have to alter a particular component or a "style object" (imgLinkStyles, buttonStyle etc.)