### PR TITLE
Block changes and additions for various sections and conditions.

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -79,7 +79,11 @@ $ const buttonStyle = {
         <on-the-move-list-item-block content=content img-styles=imgStyles />
       </if>
 
-      <else-if(sectionName === 'Podcast' || sectionName === 'Podcasts')>
+      <else-if(sectionName === 'From Diverse - At Large' && content.type === 'promotion')>
+        <diverse-at-large-promo-block content=content />
+      </else-if>
+
+      <else-if(sectionName === 'Podcast')>
         <podcast-list-item-block
           content=content
           img-styles=imgStyles
@@ -107,6 +111,16 @@ $ const buttonStyle = {
           content-url=contentUrl
           img-styles=imgStyles
           img-link-styles=imgLinkStyles
+        />
+      </else-if>
+
+      <else-if(sectionName === 'From DiverseEducation.com')>
+        <common-content-no-image-list-item-block
+          content=content
+          content-url=contentUrl
+          with-teaser=withTeaser
+          read-more=readMore
+          with-bullet=true
         />
       </else-if>
 

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -23,19 +23,17 @@ $ const queryParams = {
   queryFragment,
 };
 
+$ const adSlotNames = {
+  '1': { name: 'ad-slot-2'},
+  '3': { name: 'ad-slot-3'},
+};
+
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
   <if(nodes.length)>
     <if(withHeader)>
       <common-list-header-element title=sectionName />
     </if>
     <for|content, index| of=nodes>
-    <if(index === 2 && adParams)>
-        <common-ad-emailx-block
-          newsletter=adParams.newsletter
-          ad-unit=adParams.emailX.getAdUnit({ name: 'ad-slot-2', alias: newsletter.alias })
-          date=adParams.date
-        />
-    </if>
       <common-content-list-item-block
         content=content
         with-section=withSection
@@ -47,6 +45,14 @@ $ const queryParams = {
         section-name=sectionName
         read-more=readMore
       />
+    <if(( adSlotNames[index] && adParams ))>
+    $ const { name } = adSlotNames[index]
+      <common-ad-emailx-block
+        newsletter=adParams.newsletter
+        ad-unit=adParams.emailX.getAdUnit({ name, alias: newsletter.alias })
+        date=adParams.date
+      />
+    </if>
     </for>
   </if>
 </marko-web-query>

--- a/packages/common/components/blocks/content/magazine-cover.marko
+++ b/packages/common/components/blocks/content/magazine-cover.marko
@@ -4,7 +4,7 @@ import { getAsObject } from "@parameter1/base-cms-object-path";
 import queryFragment from "@cox-matthews-associates/package-common/graphql/fragments/content-list";
 
 $ const { config } = out.global;
-$ const { date, newsletter, publicationId, imgWidth } = input;
+$ const { date, newsletter, publicationId } = input;
 
 $ const sectionStyle = {
   "font-size": "15px",
@@ -32,14 +32,13 @@ $ const buttonStyle = {
   "padding": "12px",
 };
 
-<marko-web-query|{ node: latestIssue, nodes }|
+<marko-web-query|{ node: latestIssue }|
   name="magazine-latest-issue"
   params={
   publicationId: publicationId,
   queryFragment: latestIssueFragment
   }
 >
-
   <tr>
     <td align="center" valign="top">
       <table role="presentation" width="100%" border="0" align="center"  cellpadding="0" cellspacing="0">
@@ -60,41 +59,23 @@ $ const buttonStyle = {
   </tr>
   <tr>
     <td align="center" valign="top">
-      <table role="presentation" width="100%" border="0" align="center"  cellpadding="0" cellspacing="0">
+      <table role="presentation" width="25%" border="0" align="left"  cellpadding="0" cellspacing="0">
         <tr>
-          <td align="center">
+          <td align="left" style="padding-left: 15px">
             <marko-core-obj-value|{ value: coverImage }| obj=latestIssue field="coverImage" as="object">
               <marko-newsletter-imgix
                 src=coverImage.src
                 alt=coverImage.alt
-                options={ w: imgWidth }
-                attrs={ border: 0, width: imgWidth }
+                attrs={ border: 0, width: 200, height: 200 }
               >
                 <@link href=latestIssue.digitalEditionUrl target="_blank" />
               </marko-newsletter-imgix>
             </marko-core-obj-value>
           </td>
+          <table>
+            <from-the-magazine-block date=date newsletter=newsletter />
+          </table>
         </tr>
-        <common-table-spacer-element />
-        <table role="presentation" width="600" border="0" align="center"  cellpadding="0" cellspacing="0">
-          <tr>
-            <td>
-              <a href=latestIssue.digitalEditionUrl target="_blank">
-                <span style=buttonStyle>Digital Edition</span>
-              </a>
-            </td>
-            <td>
-              <a href="https://diverse.dragonforms.com/loading.do?omedasite=di_new" target="_blank">
-                <span style=buttonStyle>Subscribe</span>
-              </a>
-            </td>
-            <td align="right">
-              <a href="https://www.diverseeducation.com/magazine/61128276dc429e5a098b4576" target="_blank">
-                <span style=buttonStyle>Archives</span>
-              </a>
-            </td>
-          </tr>
-        </table>
         <common-table-spacer-element height=32 />
       </table>
     </td>

--- a/packages/common/components/blocks/content/no-image.marko
+++ b/packages/common/components/blocks/content/no-image.marko
@@ -1,9 +1,9 @@
-$ const { content, contentUrl, withTeaser, readMore } = input;
+$ const { content, contentUrl, withTeaser, readMore, withBullet } = input;
 
 <tr>
   <td align="left" valign="top">
     <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
-      ${content.name}
+      <if(withBullet)>&bull;  </if>${content.name}
     </a>
   </td>
 </tr>

--- a/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
+++ b/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
@@ -1,0 +1,12 @@
+$ const { content} = input;
+
+<tr>
+</tr>
+<if(content.teaser && content.linkText && content.linkUrl)>
+  <common-table-spacer-element height="5" />
+  <tr>
+    <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+        &bull;  <a href=content.linkUrl>${content.linkText}</a> ${content.teaser}
+    </td>
+  </tr>
+</if>

--- a/packages/common/components/blocks/content/section-specific/from-the-magazine.marko
+++ b/packages/common/components/blocks/content/section-specific/from-the-magazine.marko
@@ -1,0 +1,25 @@
+import queryFragment from "@cox-matthews-associates/package-common/graphql/fragments/content-list";
+
+$ const { date, newsletter } = input;
+
+$ const queryParams = {
+  date: date.valueOf(),
+  newsletterId: newsletter.id,
+  sectionName: 'From the Magazine',
+  queryFragment,
+};
+
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
+  <if(nodes.length)>
+    <for|content, index| of=nodes>
+      <tr>
+          <td align="left" valign="top" style="padding-left: 5px; padding-right: 15px">
+            <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=content.siteContext.url>
+              &bull;  ${content.name}
+            </a>
+        </td>
+      </tr>
+      <common-table-spacer-element />
+    </for>
+  </if>
+</marko-web-query>

--- a/packages/common/components/blocks/content/section-specific/marko.json
+++ b/packages/common/components/blocks/content/section-specific/marko.json
@@ -7,5 +7,11 @@
   },
   "<poll-list-item-block>": {
     "template": "./poll.marko"
+  },
+  "<diverse-at-large-promo-block>": {
+    "template": "./diverse-at-large-promo.marko"
+  },
+  "<from-the-magazine-block>": {
+    "template": "./from-the-magazine.marko"
   }
 }

--- a/packages/common/components/blocks/header-with-date.marko
+++ b/packages/common/components/blocks/header-with-date.marko
@@ -8,6 +8,17 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const name = (newsletterConfig.name || newsletter.name);
 $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
 
+$ const dateData = {
+  'Diverse Weekly Recap': {
+    align: "right",
+    display: `${date.weekday(1).format("MMMM DD")} - ${date.weekday(6).format("MMMM DD, YYYY")}`
+  },
+  'Diverse Daily': {
+    align: "center",
+    display: `${input.date.format(dateFormat)}`
+  }
+};
+
 <tr>
   <td align="center" valign="top">
     <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
@@ -22,8 +33,8 @@ $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
             </tr>
             <common-table-spacer-element height="20" />
             <tr>
-              <td align="center" valign="center" style="font-weight: 700">
-                ${name} - ${input.date.format(dateFormat)}
+              <td align=`${dateData[name].align}` valign="center" style="font-weight: 700">
+                  ${dateData[name].display}
               </td>
             </tr>
           </table>

--- a/packages/common/components/blocks/marko.json
+++ b/packages/common/components/blocks/marko.json
@@ -18,7 +18,7 @@
   "<common-view-online-block>": {
     "template": "./view-online.marko"
   },
-  "<common-daily-header-block>": {
-    "template": "./daily-header.marko"
+  "<common-header-with-date-block>": {
+    "template": "./header-with-date.marko"
   }
 }

--- a/packages/common/components/elements/list-header.marko
+++ b/packages/common/components/elements/list-header.marko
@@ -1,3 +1,10 @@
+$ const { title } = input;
+
+$ const linkTo = {
+  "On the Move": "https://www.diverseeducation.com/on-the-move",
+  "New Hires": "https://www.diverseeducation.com/on-the-move",
+};
+
 <tr>
   <td align="center" valign="top">
     <table role="presentation" width="100%" border="0" align="center"  cellpadding="0" cellspacing="0">
@@ -8,7 +15,7 @@
               <tbody>
                 <tr>
                   <td align="center" valign="middle" height="38">
-                    <a href="#" target="_blank" style="font-size:15px;color: #000000;text-decoration: none;display: block;font-weight:700;font-family:'Roboto', Arial, sans-serif;text-transform: uppercase;padding: 0 24px;" >&nbsp;${input.title}&nbsp;</a>
+                    <a href=`${linkTo[title]}` target="_blank" style="font-size:15px;color: #000000;text-decoration: none;display: block;font-weight:700;font-family:'Roboto', Arial, sans-serif;text-transform: uppercase;padding: 0 24px;" >&nbsp;${title}&nbsp;</a>
                   </td>
                 </tr>
               </tbody>

--- a/packages/common/components/layouts/ccnews-now.marko
+++ b/packages/common/components/layouts/ccnews-now.marko
@@ -40,6 +40,13 @@ $ const nativeX = config.getAsObject("nativeX");
           }
         />
 
+        <!-- Ad Slot 4 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
+          date=date
+        />
+
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -61,13 +68,6 @@ $ const nativeX = config.getAsObject("nativeX");
           placement-id=get(nativeX, `placements.${newsletter.alias}.native-slot-1`)
         /> -->
 
-        <!-- Ad Slot 3 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
-          date=date
-        />
-
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -75,13 +75,6 @@ $ const nativeX = config.getAsObject("nativeX");
           with-section=false
           section-name="Featured Employers"
           newsletter=newsletter
-        />
-
-        <!-- Ad Slot 4 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
-          date=date
         />
 
         <!-- Content list block -->

--- a/packages/common/components/layouts/daily.marko
+++ b/packages/common/components/layouts/daily.marko
@@ -42,6 +42,13 @@ $ const nativeX = config.getAsObject("nativeX");
           }
         />
 
+        <!-- Ad Slot 4 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
+          date=date
+        />
+
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -79,13 +86,6 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
         />
 
-        <!-- Ad Slot 3 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
-          date=date
-        />
-
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -107,13 +107,6 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
         />
 
-        <!-- Ad Slot 4 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
-          date=date
-        />
-
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -128,7 +121,7 @@ $ const nativeX = config.getAsObject("nativeX");
           date=date
           with-header=true
           with-section=false
-          section-name="Podcasts"
+          section-name="Podcast"
           newsletter=newsletter
         />
 

--- a/packages/common/components/layouts/health.marko
+++ b/packages/common/components/layouts/health.marko
@@ -41,6 +41,13 @@ $ const nativeX = config.getAsObject("nativeX");
           }
         />
 
+        <!-- Ad Slot 4 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
+          date=date
+        />
+
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -61,13 +68,6 @@ $ const nativeX = config.getAsObject("nativeX");
           placement-id=get(nativeX, `placements.${newsletter.alias}.native-slot-1`)
         /> -->
 
-        <!-- Ad Slot 3 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
-          date=date
-        />
-
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -75,13 +75,6 @@ $ const nativeX = config.getAsObject("nativeX");
           with-section=false
           section-name="Featured Jobs"
           newsletter=newsletter
-        />
-
-        <!-- Ad Slot 4 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
-          date=date
         />
 
       </@body>

--- a/packages/common/components/layouts/hiring.marko
+++ b/packages/common/components/layouts/hiring.marko
@@ -36,6 +36,18 @@ $ const nativeX = config.getAsObject("nativeX");
           image-position="right"
           newsletter=newsletter
           limit=1
+          ad-params={
+            newsletter,
+            emailX,
+            date
+          }
+        />
+
+        <!-- Ad Slot 4 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
+          date=date
         />
 
         <!-- Content list block -->
@@ -46,13 +58,6 @@ $ const nativeX = config.getAsObject("nativeX");
           section-name="Main"
           newsletter=newsletter
           skip=1
-        />
-
-        <!-- Ad Slot 2 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-2', alias: newsletter.alias })
-          date=date
         />
 
         <!-- Content list block -->
@@ -76,13 +81,6 @@ $ const nativeX = config.getAsObject("nativeX");
           placement-id=get(nativeX, `placements.${newsletter.alias}.native-slot-1`)
         /> -->
 
-        <!-- Ad Slot 3 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
-          date=date
-        />
-
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -90,13 +88,6 @@ $ const nativeX = config.getAsObject("nativeX");
           with-section=false
           section-name="Diverse Executive Careers"
           newsletter=newsletter
-        />
-
-        <!-- Ad Slot 4 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
-          date=date
         />
 
         <!-- Content list block -->

--- a/packages/common/components/layouts/military.marko
+++ b/packages/common/components/layouts/military.marko
@@ -41,6 +41,13 @@ $ const nativeX = config.getAsObject("nativeX");
           }
         />
 
+        <!-- Ad Slot 4 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
+          date=date
+        />
+
         <!-- Content list block -->
         <common-content-list-block
           date=date
@@ -59,20 +66,6 @@ $ const nativeX = config.getAsObject("nativeX");
           promotion-component="advertisement-block"
           placement-id=get(nativeX, `placements.${newsletter.alias}.native-slot-1`)
         /> -->
-
-        <!-- Ad Slot 3 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
-          date=date
-        />
-
-        <!-- Ad Slot 4 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
-          date=date
-        />
 
       </@body>
     </common-body-wrapper-block>

--- a/packages/common/components/layouts/weekly.marko
+++ b/packages/common/components/layouts/weekly.marko
@@ -17,7 +17,7 @@ $ const nativeX = config.getAsObject("nativeX");
     <common-head-block />
   </@head>
   <@body style="padding:0; margin:0;font-family: 'Roboto', Arial, sans-serif; -webkit-text-size-adjust:100%;">
-    <common-body-wrapper-block newsletter=newsletter date=date footer=input.footer>
+    <common-body-wrapper-block newsletter=newsletter date=date header=input.header footer=input.footer>
       <@body>
 
         <!-- Ad Slot 1 -->
@@ -40,6 +40,13 @@ $ const nativeX = config.getAsObject("nativeX");
             emailX,
             date
           }
+        />
+
+        <!-- Ad Slot 4 -->
+        <common-ad-emailx-block
+          newsletter=newsletter
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
+          date=date
         />
 
         <!-- Magazine Cover block -->
@@ -68,28 +75,14 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
         />
 
-        <!-- Ad Slot 3 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
-          date=date
-        />
-
         <!-- Content list block -->
         <common-content-list-block
           date=date
           with-header=true
           with-section=false
           with-image=false
-          section-name="In the Margins"
+          section-name="Podcast"
           newsletter=newsletter
-        />
-
-        <!-- Ad Slot 4 -->
-        <common-ad-emailx-block
-          newsletter=newsletter
-          ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
-          date=date
         />
 
         <!-- Content list block -->

--- a/tenants/all/templates/diverse-daily.marko
+++ b/tenants/all/templates/diverse-daily.marko
@@ -2,6 +2,6 @@ $ const { newsletter, date } = data;
 
 <common-daily-layout data=data>
   <@header>
-    <common-daily-header-block date=date newsletter=newsletter />
+    <common-header-with-date-block date=date newsletter=newsletter />
   </@header>
 </common-daily-layout>

--- a/tenants/all/templates/diverse-weekly-recap.marko
+++ b/tenants/all/templates/diverse-weekly-recap.marko
@@ -1,1 +1,7 @@
-<common-weekly-layout data=data />
+$ const { newsletter, date } = data;
+
+<common-weekly-layout data=data>
+  <@header>
+    <common-header-with-date-block date=date newsletter=newsletter />
+  </@header>
+</common-weekly-layout>


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2022-01-19 at 3 17 26 PM" src="https://user-images.githubusercontent.com/46794001/150215287-e58a5677-6fd9-4836-ad7e-2f8591c34b6b.png">


These include ad placements, treatment of promotions in Diverse at large, other no-image blocks requiring bullet points, the magazine block layout change and links for the On The Move section for both On The Move and New Hires NL sections.