### PR TITLE
Revert changes to header and footer logos

### DIFF
--- a/packages/common/components/blocks/footer.marko
+++ b/packages/common/components/blocks/footer.marko
@@ -41,21 +41,6 @@ $ const taglineStyle = {
   "padding-top": "5px",
 }
 
-$ const logoSrc = newsletterConfig.logoSrc;
-
-$ const alt = defaultValue(input.alt, newsletter.name);
-
-$ const logoStyles = {
-  "border": "0",
-  "font-size": "0",
-  "line-height": "0",
-}
-
-$ const linkStyles = {
-  "display": "block",
-  "font-size": "0",
-  "line-height": "0",
-}
 <tr>
   <td align="center" valign="top">
     <table role="presentation" width="100%" border="0" align="center"  cellpadding="0" cellspacing="0">
@@ -66,12 +51,7 @@ $ const linkStyles = {
                 <common-table-spacer-element height="18" />
                 <tr>
                   <td align="center" valign="top">
-                    <marko-newsletter-imgix
-                      src=logoSrc
-                      alt=alt
-                      attrs={ border: "0", style: logoStyles }>
-                        <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
-                    </marko-newsletter-imgix>
+                    <common-logo-element newsletter=newsletter alt=publicationName />
                   </td>
                 </tr>
                 <if(tagline)>

--- a/packages/common/components/elements/logo.marko
+++ b/packages/common/components/elements/logo.marko
@@ -12,8 +12,7 @@ $ const alt = defaultValue(input.alt, newsletter.name);
 $ const logoStyles = {
   "border": "0",
   "font-size": "0",
-  "line-height": "0",
-  "width": "600px"
+  "line-height": "0"
 }
 
 $ const linkStyles = {


### PR DESCRIPTION
<img width="662" alt="Screen Shot 2022-01-20 at 11 52 48 AM" src="https://user-images.githubusercontent.com/64623209/150394405-dcbc0e51-4ac6-47e7-91eb-1d696f439a0a.png">
