### PR TITLE
Add additional table to support button styling for 

### DIFF
--- a/packages/common/components/blocks/content/section-specific/poll.marko
+++ b/packages/common/components/blocks/content/section-specific/poll.marko
@@ -19,9 +19,13 @@ $ const { content, withTeaser, voteNow, contentUrl, buttonStyle } = input;
   <common-table-spacer-element height="9" />
   <tr>
     <td align="center" valign="middle">
-      <a href=contentUrl target="_blank">
-        <span style=buttonStyle>&nbsp;Vote Now&nbsp;</span>
-      </a>
+      <table cellpadding="0" align="center" cellspacing="0" style=buttonStyle>
+        <tr>
+          <td align="center" valign="middle">
+            <a href=contentUrl target="_blank" style="text-decoration: none; color: #ffffff;">Vote Now</a>
+          </td>
+        </tr>
+      </table>
     </td>
   </tr>
 </if>


### PR DESCRIPTION
Outlook email on acid testing

<img width="935" alt="Screen Shot 2022-01-20 at 1 25 51 PM" src="https://user-images.githubusercontent.com/64623209/150408471-6c31bd0d-9d43-450a-9d92-5b68adc7bf92.png">
