### PR TITLE
Adjust diverse-at-large block

### DIFF
--- a/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
+++ b/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
@@ -7,10 +7,8 @@ $ const { content} = input;
     </td>
   </tr>
 </if>
-<else-if(content.body)>
-  <tr>
-    <td align="left" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
-        $!{content.body}
-    </td>
-  </tr>
-</else-if>
+<tr>
+  <td align="left" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+      $!{content.body}
+  </td>
+</tr>

--- a/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
+++ b/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
@@ -1,9 +1,9 @@
 $ const { content} = input;
 
-<if(content.teaser && content.linkText && content.linkUrl)>
+<if(content.linkText && content.linkUrl)>
   <tr>
     <td align="left" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
-        &bull;  ${content.name}<br/>${content.teaser} <a href=content.linkUrl>${content.linkText}</a>
+        &bull;  <a href=content.linkUrl>${content.linkText}</a>
     </td>
   </tr>
 </if>

--- a/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
+++ b/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
@@ -1,12 +1,16 @@
 $ const { content} = input;
 
-<tr>
-</tr>
 <if(content.teaser && content.linkText && content.linkUrl)>
-  <common-table-spacer-element height="5" />
   <tr>
     <td align="left" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
-        &bull;  <a href=content.linkUrl>${content.linkText}</a> ${content.teaser}
+        &bull;  ${content.name}<br/>${content.teaser} <a href=content.linkUrl>${content.linkText}</a>
     </td>
   </tr>
 </if>
+<else-if(content.body)>
+  <tr>
+    <td align="left" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+        $!{content.body}
+    </td>
+  </tr>
+</else-if>


### PR DESCRIPTION
This will allow the option to have name, teaser, & link Text or only content.body

Name, Teaser & Link Text:
<img width="674" alt="Screen Shot 2022-01-24 at 9 53 14 AM" src="https://user-images.githubusercontent.com/64623209/150819938-71f6674a-153b-403f-979e-e14b234e859c.png">

Content Body:
<img width="648" alt="Screen Shot 2022-01-24 at 10 07 45 AM" src="https://user-images.githubusercontent.com/64623209/150819969-e95614a0-884b-4ced-a998-3079208f685f.png">
