### PR TITLE
Header logo changes

### DIFF
--- a/packages/common/components/blocks/content/section-specific/podcast.marko
+++ b/packages/common/components/blocks/content/section-specific/podcast.marko
@@ -8,7 +8,7 @@ $ const { content, imgStyles, imgLinkStyles, readMore, contentUrl, voteNow } = i
           <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
             <tr>
               <td align="left" valign="top">
-                <a style="font-size: 24px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl>
+                <a style="font-size: 20px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl>
                   ${content.name}
                 </a>
               </td>

--- a/packages/common/components/blocks/header-with-date.marko
+++ b/packages/common/components/blocks/header-with-date.marko
@@ -12,8 +12,8 @@ $ const displayDate = date.clone();
 
 $ const dateData = {
   'Diverse Weekly Recap': {
-    align: "right",
-    display: `${displayDate.weekday(1).format("MMMM DD")} - ${displayDate.weekday(6).format("MMMM DD, YYYY")}`
+    align: "center",
+    display: `${displayDate.weekday(1).format("MMMM DD")} - ${displayDate.weekday(5).format("MMMM DD, YYYY")}`
   },
   'Diverse Daily': {
     align: "center",

--- a/packages/common/components/blocks/header-with-date.marko
+++ b/packages/common/components/blocks/header-with-date.marko
@@ -13,7 +13,8 @@ $ const alt = defaultValue(input.alt, newsletter.name);
 $ const logoStyles = {
   "border": "0",
   "font-size": "0",
-  "line-height": "0"
+  "line-height": "0",
+  "width": "600px"
 }
 
 $ const linkStyles = {
@@ -47,7 +48,6 @@ $ const dateData = {
                 <marko-newsletter-imgix
                   src=logoSrc
                   alt=alt
-                  options={ fit: "max" }
                   attrs={ border: "0", style: logoStyles }>
                     <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>

--- a/packages/common/components/blocks/header-with-date.marko
+++ b/packages/common/components/blocks/header-with-date.marko
@@ -13,8 +13,7 @@ $ const alt = defaultValue(input.alt, newsletter.name);
 $ const logoStyles = {
   "border": "0",
   "font-size": "0",
-  "line-height": "0",
-  "width": "600px"
+  "line-height": "0"
 }
 
 $ const linkStyles = {
@@ -48,6 +47,7 @@ $ const dateData = {
                 <marko-newsletter-imgix
                   src=logoSrc
                   alt=alt
+                  options={ fit: "max" }
                   attrs={ border: "0", style: logoStyles }>
                     <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>

--- a/packages/common/components/blocks/header-with-date.marko
+++ b/packages/common/components/blocks/header-with-date.marko
@@ -1,13 +1,28 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { config } = out.global
+$ const { website, config } = out.global
 
 $ const { newsletter, date } = input;
 
 $ const newsletterConfig = config.get(newsletter.alias);
 $ const name = (newsletterConfig.name || newsletter.name);
-$ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
+$ const logoSrc = newsletterConfig.logoSrc;
 
+$ const alt = defaultValue(input.alt, newsletter.name);
+
+$ const logoStyles = {
+  "border": "0",
+  "font-size": "0",
+  "line-height": "0",
+  "width": "600px"
+}
+
+$ const linkStyles = {
+  "display": "block",
+  "font-size": "0",
+  "line-height": "0",
+}
+$ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
 $ const displayDate = date.clone();
 
 $ const dateData = {
@@ -30,7 +45,12 @@ $ const dateData = {
           <table role="presentation" width="610" border="0" cellspacing="0" cellpadding="0" class="wrap003">
             <tr>
               <td align="center" valign="center">
-                <common-logo-element newsletter=newsletter />
+                <marko-newsletter-imgix
+                  src=logoSrc
+                  alt=alt
+                  attrs={ border: "0", style: logoStyles }>
+                    <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
+                </marko-newsletter-imgix>
               </td>
             </tr>
             <common-table-spacer-element height="20" />

--- a/packages/common/components/blocks/header.marko
+++ b/packages/common/components/blocks/header.marko
@@ -14,8 +14,7 @@ $ const alt = defaultValue(input.alt, newsletter.name);
 $ const logoStyles = {
   "border": "0",
   "font-size": "0",
-  "line-height": "0",
-  "width": "600px"
+  "line-height": "0"
 }
 
 $ const linkStyles = {
@@ -36,6 +35,7 @@ $ const linkStyles = {
                 <marko-newsletter-imgix
                   src=logoSrc
                   alt=alt
+                  options={ fit: "max" }
                   attrs={ border: "0", style: logoStyles }>
                     <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>

--- a/packages/common/components/blocks/header.marko
+++ b/packages/common/components/blocks/header.marko
@@ -14,7 +14,8 @@ $ const alt = defaultValue(input.alt, newsletter.name);
 $ const logoStyles = {
   "border": "0",
   "font-size": "0",
-  "line-height": "0"
+  "line-height": "0",
+  "width": "600px"
 }
 
 $ const linkStyles = {
@@ -35,7 +36,6 @@ $ const linkStyles = {
                 <marko-newsletter-imgix
                   src=logoSrc
                   alt=alt
-                  options={ fit: "max" }
                   attrs={ border: "0", style: logoStyles }>
                     <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>

--- a/packages/common/components/blocks/header.marko
+++ b/packages/common/components/blocks/header.marko
@@ -1,12 +1,28 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { config } = out.global
+$ const { website, config } = out.global
 
 $ const { newsletter, date } = input;
 
 $ const newsletterConfig = config.get(newsletter.alias);
 $ const name = (newsletterConfig.name || newsletter.name);
 $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
+$ const logoSrc = newsletterConfig.logoSrc;
+
+$ const alt = defaultValue(input.alt, newsletter.name);
+
+$ const logoStyles = {
+  "border": "0",
+  "font-size": "0",
+  "line-height": "0",
+  "width": "600px"
+}
+
+$ const linkStyles = {
+  "display": "block",
+  "font-size": "0",
+  "line-height": "0",
+}
 
 <tr>
   <td align="center" valign="top">
@@ -17,7 +33,12 @@ $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
           <table role="presentation" width="610" border="0" cellspacing="0" cellpadding="0" class="wrap003">
             <tr>
               <td align="center" valign="center">
-                <common-logo-element newsletter=newsletter />
+                <marko-newsletter-imgix
+                  src=logoSrc
+                  alt=alt
+                  attrs={ border: "0", style: logoStyles }>
+                    <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
+                </marko-newsletter-imgix>
               </td>
             </tr>
             <common-table-spacer-element height="20" />

--- a/tenants/all/config/brands.js
+++ b/tenants/all/config/brands.js
@@ -20,12 +20,12 @@ module.exports = {
   },
   health: {
     brandName: 'Diverse Health',
-    logoSrc: '/files/base/diverse/all/image/static/dh-logo.png',
+    logoSrc: '/files/base/diverse/all/image/static/health.jpeg',
     subscribeLink: '',
   },
   hiring: {
     brandName: 'Diverse Hiring',
-    logoSrc: '/files/base/diverse/all/image/static/diverse-hiring-logo.png',
+    logoSrc: '/files/base/diverse/all/image/static/diverseHiring.jpeg',
     subscribeLink: '',
   },
 };

--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -33,7 +33,7 @@ const config = {
   },
   'diverse-weekly-recap': {
     name: 'Diverse Weekly Recap',
-    logoSrc: '/files/base/diverse/all/image/static/weekly-recap-logo.png',
+    logoSrc: '/files/base/diverse/all/image/static/WeeklyRecap.jpeg',
     ...brands.diverse,
   },
 };


### PR DESCRIPTION
Weekly Recap:
![screencapture-localhost-22290-templates-diverse-weekly-recap-2022-01-25-09_17_40](https://user-images.githubusercontent.com/64623209/151005792-98bfcb52-4ac1-4401-b2c6-d74a588d0969.png)
Email On Acid:
<img width="482" alt="Screen Shot 2022-01-25 at 9 24 01 AM" src="https://user-images.githubusercontent.com/64623209/151005842-87c921a3-9174-4fdf-a647-3fa4459cce08.png">
Hiring:
<img width="640" alt="Screen Shot 2022-01-25 at 11 53 10 AM" src="https://user-images.githubusercontent.com/64623209/151032234-be23b8a0-06be-4b58-9596-54a5a42757d2.png">
Military:
<img width="642" alt="Screen Shot 2022-01-25 at 11 53 00 AM" src="https://user-images.githubusercontent.com/64623209/151032270-ff157bbc-b8b3-4c8f-bce4-e3638a7a7905.png">
Health:
<img width="638" alt="Screen Shot 2022-01-25 at 11 53 18 AM" src="https://user-images.githubusercontent.com/64623209/151032300-4e4b739d-a227-467e-818f-b35a592c137b.png">
