### PR TITLE
Add options to header logo so it doesn’t default to 320x320

### DIFF
--- a/packages/common/components/blocks/header-with-date.marko
+++ b/packages/common/components/blocks/header-with-date.marko
@@ -14,7 +14,6 @@ $ const logoStyles = {
   "border": "0",
   "font-size": "0",
   "line-height": "0",
-  "width": "600px"
 }
 
 $ const linkStyles = {
@@ -48,6 +47,7 @@ $ const dateData = {
                 <marko-newsletter-imgix
                   src=logoSrc
                   alt=alt
+                  options= { w: 600 }
                   attrs={ border: "0", style: logoStyles }>
                     <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>

--- a/packages/common/components/blocks/header.marko
+++ b/packages/common/components/blocks/header.marko
@@ -15,7 +15,6 @@ $ const logoStyles = {
   "border": "0",
   "font-size": "0",
   "line-height": "0",
-  "width": "600px"
 }
 
 $ const linkStyles = {
@@ -35,6 +34,7 @@ $ const linkStyles = {
               <td align="center" valign="center">
                 <marko-newsletter-imgix
                   src=logoSrc
+                  options={ w: 600 }
                   alt=alt
                   attrs={ border: "0", style: logoStyles }>
                     <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />


### PR DESCRIPTION
<img width="910" alt="Screen Shot 2022-01-25 at 2 21 11 PM" src="https://user-images.githubusercontent.com/64623209/151053668-4ade9037-67e1-4f68-b7fb-7c655ffe8ead.png">
