### PR TITLE
Header logo height option added, font size increase, add teaser on the move on mobile

### DIFF
--- a/packages/common/components/blocks/content/no-image.marko
+++ b/packages/common/components/blocks/content/no-image.marko
@@ -2,7 +2,7 @@ $ const { content, contentUrl, withTeaser, readMore, withBullet } = input;
 
 <tr>
   <td align="left" valign="top">
-    <a style="font-size: 20px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
+    <a style="font-size: 22px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
       <if(withBullet)>&bull;  </if>${content.name}
     </a>
   </td>
@@ -10,7 +10,7 @@ $ const { content, contentUrl, withTeaser, readMore, withBullet } = input;
 <if(withTeaser)>
   <common-table-spacer-element height="5" />
   <tr>
-    <td align="left" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+    <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
       ${content.teaser}
     </td>
   </tr>

--- a/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
+++ b/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
@@ -2,13 +2,13 @@ $ const { content} = input;
 
 <if(content.linkText && content.linkUrl)>
   <tr>
-    <td align="left" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+    <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
         &bull;  <a href=content.linkUrl>${content.linkText}</a>
     </td>
   </tr>
 </if>
 <tr>
-  <td align="left" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+  <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
       $!{content.body}
   </td>
 </tr>

--- a/packages/common/components/blocks/content/section-specific/from-the-magazine.marko
+++ b/packages/common/components/blocks/content/section-specific/from-the-magazine.marko
@@ -14,7 +14,7 @@ $ const queryParams = {
     <for|content, index| of=nodes>
       <tr>
         <td align="left" valign="top" style="padding-left: 20px; padding-right: 15px">
-          <a style="font-size: 20px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=content.siteContext.url>
+          <a style="font-size: 22px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=content.siteContext.url>
             &bull;&nbsp;&nbsp;${content.name}
           </a>
         </td>

--- a/packages/common/components/blocks/content/section-specific/on-the-move.marko
+++ b/packages/common/components/blocks/content/section-specific/on-the-move.marko
@@ -18,7 +18,7 @@ $ const contentUrl = `${content.siteContext.url}${queryString}`
             </tr>
             <tr>
               <td>
-                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
+                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="show_on_mobile">
                   <common-table-spacer-element height="5" />
                   <tr>
                     <td align="left" valign="top" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">

--- a/packages/common/components/blocks/content/section-specific/on-the-move.marko
+++ b/packages/common/components/blocks/content/section-specific/on-the-move.marko
@@ -12,7 +12,7 @@ $ const contentUrl = `${content.siteContext.url}${queryString}`
         <td align="left" valign="top">
           <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
             <tr>
-              <td align="left" valign="top" style="font-size: 20px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;">
+              <td align="left" valign="top" style="font-size: 22px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;">
                   ${content.name}
               </td>
             </tr>
@@ -21,7 +21,7 @@ $ const contentUrl = `${content.siteContext.url}${queryString}`
                 <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="show_on_mobile">
                   <common-table-spacer-element height="5" />
                   <tr>
-                    <td align="left" valign="top" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+                    <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
                       ${content.teaser}
                     </td>
                   </tr>
@@ -55,7 +55,7 @@ $ const contentUrl = `${content.siteContext.url}${queryString}`
     <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
       <common-table-spacer-element height="10" />
       <tr>
-        <td align="left" valign="top" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+        <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
           ${content.teaser}
         </td>
       </tr>

--- a/packages/common/components/blocks/content/section-specific/podcast.marko
+++ b/packages/common/components/blocks/content/section-specific/podcast.marko
@@ -8,7 +8,7 @@ $ const { content, imgStyles, imgLinkStyles, readMore, contentUrl, voteNow } = i
           <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
             <tr>
               <td align="left" valign="top">
-                <a style="font-size: 20px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl>
+                <a style="font-size: 22px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" class="font1" href=contentUrl>
                   ${content.name}
                 </a>
               </td>
@@ -18,7 +18,7 @@ $ const { content, imgStyles, imgLinkStyles, readMore, contentUrl, voteNow } = i
                 <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
                   <common-table-spacer-element height="5" />
                   <tr>
-                    <td align="left" valign="top" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+                    <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
                       ${content.teaser}
                     </td>
                   </tr>
@@ -51,7 +51,7 @@ $ const { content, imgStyles, imgLinkStyles, readMore, contentUrl, voteNow } = i
     <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
       <common-table-spacer-element height="10" />
       <tr>
-        <td align="left" valign="top" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+        <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
           ${content.teaser}
         </td>
       </tr>

--- a/packages/common/components/blocks/content/section-specific/poll.marko
+++ b/packages/common/components/blocks/content/section-specific/poll.marko
@@ -2,7 +2,7 @@ $ const { content, withTeaser, voteNow, contentUrl, buttonStyle } = input;
 
 <tr>
   <td align="center" valign="top">
-    <a style="font-size: 20px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
+    <a style="font-size: 22px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
       ${content.name}
     </a>
   </td>
@@ -10,7 +10,7 @@ $ const { content, withTeaser, voteNow, contentUrl, buttonStyle } = input;
 <if(withTeaser)>
   <common-table-spacer-element height="5" />
   <tr>
-    <td align="center" valign="middle" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+    <td align="center" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
       ${content.teaser}
     </td>
   </tr>

--- a/packages/common/components/blocks/content/with-image.marko
+++ b/packages/common/components/blocks/content/with-image.marko
@@ -18,7 +18,7 @@ $ const { content, readMore, contentUrl, imgStyles, imgLinkStyles } = input;
                 <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
                   <common-table-spacer-element height="5" />
                   <tr>
-                    <td align="left" valign="top" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+                    <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
                       ${content.teaser}
                     </td>
                   </tr>
@@ -53,7 +53,7 @@ $ const { content, readMore, contentUrl, imgStyles, imgLinkStyles } = input;
     <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
       <common-table-spacer-element height="10" />
       <tr>
-        <td align="left" valign="top" style="font-size: 15px;line-height: 23px;color: #202022;font-weight: 400;">
+        <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
           ${content.teaser}
         </td>
       </tr>

--- a/packages/common/components/blocks/header-with-date.marko
+++ b/packages/common/components/blocks/header-with-date.marko
@@ -47,7 +47,7 @@ $ const dateData = {
                 <marko-newsletter-imgix
                   src=logoSrc
                   alt=alt
-                  options= { w: 600, h: 100 }
+                  options= { w: 600, h: 100, fit: "fill", fillColor: "ffffff" }
                 >
                   <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>

--- a/packages/common/components/blocks/header-with-date.marko
+++ b/packages/common/components/blocks/header-with-date.marko
@@ -47,9 +47,9 @@ $ const dateData = {
                 <marko-newsletter-imgix
                   src=logoSrc
                   alt=alt
-                  options= { w: 600 }
-                  attrs={ border: "0", style: logoStyles }>
-                    <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
+                  options= { w: 600, h: 100 }
+                >
+                  <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>
               </td>
             </tr>

--- a/packages/common/components/blocks/header.marko
+++ b/packages/common/components/blocks/header.marko
@@ -34,14 +34,13 @@ $ const linkStyles = {
               <td align="center" valign="center">
                 <marko-newsletter-imgix
                   src=logoSrc
-                  options={ w: 600 }
                   alt=alt
-                  attrs={ border: "0", style: logoStyles }>
-                    <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
+                  options= { w: 600, h: 140 }
+                >
+                  <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>
               </td>
             </tr>
-            <common-table-spacer-element height="20" />
           </table>
         </td>
       </tr>

--- a/packages/common/components/blocks/header.marko
+++ b/packages/common/components/blocks/header.marko
@@ -35,7 +35,7 @@ $ const linkStyles = {
                 <marko-newsletter-imgix
                   src=logoSrc
                   alt=alt
-                  options= { w: 600, h: 140 }
+                  options= { w: 600,  h: 100, fit: "fill", fillColor: "ffffff" }
                 >
                   <@link href=website.get("origin") attrs={ style: linkStyles } target="_blank" />
                 </marko-newsletter-imgix>


### PR DESCRIPTION
Updated logos:
<img width="648" alt="Screen Shot 2022-01-26 at 12 19 57 PM" src="https://user-images.githubusercontent.com/64623209/151223306-819e76da-f1ba-4677-b018-96601d3f0b11.png">
<img width="636" alt="Screen Shot 2022-01-26 at 12 20 04 PM" src="https://user-images.githubusercontent.com/64623209/151223325-5a49e946-af1f-41fc-8d64-5f1ff6d80c3d.png">


![screencapture-localhost-22290-templates-diverse-daily-2022-01-26-10_39_57](https://user-images.githubusercontent.com/64623209/151206971-c9d407e9-54d9-4277-95f2-e8ea6f29ba4e.png)
![screencapture-localhost-22290-templates-ccnews-now-2022-01-26-10_40_11](https://user-images.githubusercontent.com/64623209/151207007-917c6036-33cb-4026-899b-83548f92bb6c.png)
