### PR TITLE
Remove bullets from content-no-image & from the magazine block

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -120,7 +120,6 @@ $ const buttonStyle = {
           content-url=contentUrl
           with-teaser=withTeaser
           read-more=readMore
-          with-bullet=true
         />
       </else-if>
 

--- a/packages/common/components/blocks/content/no-image.marko
+++ b/packages/common/components/blocks/content/no-image.marko
@@ -1,9 +1,9 @@
-$ const { content, contentUrl, withTeaser, readMore, withBullet } = input;
+$ const { content, contentUrl, withTeaser, readMore } = input;
 
 <tr>
   <td align="left" valign="top">
     <a style="font-size: 22px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=contentUrl>
-      <if(withBullet)>&bull;  </if>${content.name}
+      ${content.name}
     </a>
   </td>
 </tr>

--- a/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
+++ b/packages/common/components/blocks/content/section-specific/diverse-at-large-promo.marko
@@ -3,7 +3,7 @@ $ const { content, readMore, contentUrl, imgStyles, imgLinkStyles } = input;
 <if(content.linkText && content.linkUrl)>
   <tr>
     <td align="left" valign="middle" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
-        &bull;  <a href=content.linkUrl>${content.linkText}</a>
+      <a href=content.linkUrl>${content.linkText}</a>
     </td>
   </tr>
 </if>

--- a/packages/common/components/blocks/content/section-specific/from-the-magazine.marko
+++ b/packages/common/components/blocks/content/section-specific/from-the-magazine.marko
@@ -15,7 +15,7 @@ $ const queryParams = {
       <tr>
         <td align="left" valign="top" style="padding-left: 20px; padding-right: 15px">
           <a style="font-size: 22px;line-height: 28px;color: #436daa;font-weight: 700;text-decoration: none;" href=content.siteContext.url>
-            &bull;&nbsp;&nbsp;${content.name}
+            ${content.name}
           </a>
         </td>
       </tr>


### PR DESCRIPTION
Also remove with-bullet=true from list-item
Updated template:
![screencapture-localhost-22290-templates-diverse-weekly-recap-2022-01-27-11_34_05](https://user-images.githubusercontent.com/64623209/151412689-7d475dcf-7a1c-4a8c-add3-8c35c991a75e.png)
