### PR TITLE
Modify most read article from website subheader to match 'two day send' logic

### DIFF
--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -15,6 +15,7 @@ $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withLogo = defaultValue(input.withLogo, true);
 $ const forDailySend = defaultValue(input.forDailySend, false);
 $ const forTwoDaySend = defaultValue(input.forTwoDaySend, false);
+$ const forTwoDaySendWebsite = defaultValue(input.forTwoDaySendWebsite, false);
 $ const withSubheader = defaultValue(input.withSubheader, false);
 $ const adParams = input.adParams;
 $ const weekday = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
@@ -43,6 +44,12 @@ $ const queryParams = {
       $ const dayOfWeek = new Date(date).getDay();
       $ const yesterdayOfWeek = dayOfWeek === 1 ? 3 : dayOfWeek - 2;
       $ const sectionNameWithDate = sectionName.match(/most read article on e-newsletter/i) ? `Most read article in ${weekday[yesterdayOfWeek]}'s newsletter` : sectionName
+      <common-list-subheader-element title=sectionNameWithDate />
+    </if>
+    <if(forTwoDaySendWebsite)>
+      $ const dayOfWeek = new Date(date).getDay();
+      $ const yesterdayOfWeek = dayOfWeek === 1 ? 3 : dayOfWeek - 2;
+      $ const sectionNameWithDate = sectionName.match(/most read article from the website/i) ? `Most read article from the website on ${weekday[yesterdayOfWeek]}` : sectionName
       <common-list-subheader-element title=sectionNameWithDate />
     </if>
     <if(withSubheader)>

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -14,6 +14,7 @@ $ const urlParams = defaultValue(input.urlParams, false);
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withLogo = defaultValue(input.withLogo, true);
 $ const forDailySend = defaultValue(input.forDailySend, false);
+$ const isDailySend = defaultValue(input.isDailySend, false);
 $ const forTwoDaySend = defaultValue(input.forTwoDaySend, false);
 $ const isTwoDaySend = defaultValue(input.isTwoDaySend, false);
 $ const withSubheader = defaultValue(input.withSubheader, false);
@@ -38,6 +39,12 @@ $ const queryParams = {
       $ const dayOfWeek = new Date(date).getDay();
       $ const yesterdayOfWeek = dayOfWeek === 1 ? 5 : dayOfWeek - 1;
       $ const sectionNameWithDate = sectionName.match(/most read article on e-newsletter/i) ? `Most read article in ${weekday[yesterdayOfWeek]}'s newsletter` : sectionName
+      <common-list-subheader-element title=sectionNameWithDate />
+    </if>
+    <if(isDailySend)>
+      $ const dayOfWeek = new Date(date).getDay();
+      $ const yesterdayOfWeek = dayOfWeek === 1 ? 5 : dayOfWeek - 1;
+      $ const sectionNameWithDate = sectionName.match(/most read article from the website/i) ? `Most read article from the website on ${weekday[yesterdayOfWeek]}` : sectionName
       <common-list-subheader-element title=sectionNameWithDate />
     </if>
     <if(forTwoDaySend)>

--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -15,7 +15,7 @@ $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withLogo = defaultValue(input.withLogo, true);
 $ const forDailySend = defaultValue(input.forDailySend, false);
 $ const forTwoDaySend = defaultValue(input.forTwoDaySend, false);
-$ const forTwoDaySendWebsite = defaultValue(input.forTwoDaySendWebsite, false);
+$ const isTwoDaySend = defaultValue(input.isTwoDaySend, false);
 $ const withSubheader = defaultValue(input.withSubheader, false);
 $ const adParams = input.adParams;
 $ const weekday = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
@@ -46,7 +46,7 @@ $ const queryParams = {
       $ const sectionNameWithDate = sectionName.match(/most read article on e-newsletter/i) ? `Most read article in ${weekday[yesterdayOfWeek]}'s newsletter` : sectionName
       <common-list-subheader-element title=sectionNameWithDate />
     </if>
-    <if(forTwoDaySendWebsite)>
+    <if(isTwoDaySend)>
       $ const dayOfWeek = new Date(date).getDay();
       $ const yesterdayOfWeek = dayOfWeek === 1 ? 3 : dayOfWeek - 2;
       $ const sectionNameWithDate = sectionName.match(/most read article from the website/i) ? `Most read article from the website on ${weekday[yesterdayOfWeek]}` : sectionName

--- a/packages/common/components/layouts/ccnews-now.marko
+++ b/packages/common/components/layouts/ccnews-now.marko
@@ -134,7 +134,7 @@ $ const nativeX = config.getAsObject("nativeX");
 
         <common-content-list-block
           date=date
-          for-two-day-send-website=true
+          is-two-day-send=true
           with-section=false
           section-name="Most Read Article from the website"
           with-image=false

--- a/packages/common/components/layouts/ccnews-now.marko
+++ b/packages/common/components/layouts/ccnews-now.marko
@@ -134,7 +134,7 @@ $ const nativeX = config.getAsObject("nativeX");
 
         <common-content-list-block
           date=date
-          with-subheader=true
+          for-two-day-send-website=true
           with-section=false
           section-name="Most Read Article from the website"
           with-image=false

--- a/packages/common/components/layouts/daily.marko
+++ b/packages/common/components/layouts/daily.marko
@@ -98,7 +98,7 @@ $ const nativeX = config.getAsObject("nativeX");
 
         <common-content-list-block
           date=date
-          with-subheader=true
+          is-daily-send=true
           with-section=false
           section-name="Most Read Article from the website"
           with-image=false


### PR DESCRIPTION
CCNews:
<img width="778" alt="Screenshot 2024-10-14 at 10 59 14 AM" src="https://github.com/user-attachments/assets/681219d1-9f4e-46d0-bfa4-887a230f5fa3">
<img width="856" alt="Screenshot 2024-10-14 at 10 59 25 AM" src="https://github.com/user-attachments/assets/a074c7ed-799c-4a26-b43f-8f84b1136f56">

Daily:
<img width="1053" alt="Screenshot 2024-10-14 at 1 07 55 PM" src="https://github.com/user-attachments/assets/c10504bb-6162-4069-be42-562d321046ee">
<img width="1009" alt="Screenshot 2024-10-14 at 1 07 46 PM" src="https://github.com/user-attachments/assets/f2bbd841-1ef8-4b2c-8011-01073b076561">
<img width="944" alt="Screenshot 2024-10-14 at 1 07 35 PM" src="https://github.com/user-attachments/assets/2741a199-c64a-4b77-b9e3-4775fa95a738">

